### PR TITLE
Update dependabot configuration with dependency groupings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,10 @@ updates:
       k8s.io:
         patterns:
           - "k8s.io/*"
+      github.com/onsi:
+        patterns:
+          - "github.com/onsi/ginkgo/*"
+          - "github.com/onsi/gomega/*"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      k8s.io:
+        patterns:
+          - "k8s.io/*"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary
- Add k8s.io grouping for Kubernetes dependencies
- Add github.com/onsi grouping for ginkgo and gomega testing framework dependencies

## Test plan
- [ ] Verify dependabot configuration is valid

🤖 Generated with [Claude Code](https://claude.ai/code)