### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/cblecker/cluster-api-provider-jira/security/code-scanning/3](https://github.com/cblecker/cluster-api-provider-jira/security/code-scanning/3)

To fix this problem, you should add an explicit `permissions` block setting the minimum access required by the workflow. Since the current workflow only checks out the code and runs tests and does not appear to interact with the repository (such as creating releases, pushing commits, or commenting on issues), the least privilege is `contents: read`. This block can be added at the top level (under the workflow's root), which will apply to all jobs, or under the specific job. Placing it at the root is both simplest and most future-proof, ensuring any future jobs will also have minimal permissions by default. The only required change is to insert the `permissions:` block with `contents: read` after the `name:` definition in `.github/workflows/test.yml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
