### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,6 @@
 name: Lint
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/cblecker/cluster-api-provider-jira/security/code-scanning/2](https://github.com/cblecker/cluster-api-provider-jira/security/code-scanning/2)

To fix the problem, you should add an explicit `permissions` block either at the root of the workflow (affecting all jobs) or at the job level (affecting only the specified job). The minimum necessary in this case is `contents: read`, granting the workflow GITHUB_TOKEN read-only access to repository contents, which is all the current steps require. The best place for this is at the top/root level, directly beneath the workflow `name` and before `on`. This fix does not modify any workflow behavior but improves its security posture by restricting the default permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
