### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -1,4 +1,6 @@
 name: E2E Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/cblecker/cluster-api-provider-jira/security/code-scanning/1](https://github.com/cblecker/cluster-api-provider-jira/security/code-scanning/1)

The best fix is to explicitly declare the `permissions:` block in the workflow YAML file to enforce least privilege. This can be done either globally (at the root of the workflow) or within the specific job. Since the workflow currently consists of a single job, either approach is functionally equivalent, but adding it at the root is preferred for maximum clarity and future extensibility. The minimal permission in this context is `contents: read`, which allows the steps to fetch the code but avoids granting unnecessary write access. The `permissions` block should be added after the `name:` and before `on:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
